### PR TITLE
Fix: add 1MB size limit on request body to prevent DoS

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 const API = require('ep_etherpad-lite/node/db/API.js');
 const randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 
+const MAX_BODY_SIZE = 1024 * 1024; // 1 MB
+
 exports.registerRoute = (hookName, args, callback) => {
   args.app.post('/post', (req, res) => {
     let padId = req.headers['x-pad-id'];
@@ -10,12 +12,18 @@ exports.registerRoute = (hookName, args, callback) => {
       padId = randomString(8);
     }
     let content = '';
+    let aborted = false;
 
     req.on('data', (data) => {
-      // Append data.
       content += data;
+      if (content.length > MAX_BODY_SIZE) {
+        aborted = true;
+        res.status(413).send('Request body too large');
+        req.destroy();
+      }
     });
     req.on('end', async () => {
+      if (aborted) return;
       let padExists = true;
       try {
         padExists = await API.getText(padId, 0);


### PR DESCRIPTION
## Summary

The POST `/post` endpoint buffered the entire request body with no size limit. An attacker could send an arbitrarily large payload to exhaust server memory.

Now rejects requests larger than 1MB with HTTP 413 (Payload Too Large) and destroys the connection.

## Test plan

- [ ] POST with body < 1MB works as before
- [ ] POST with body > 1MB returns 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)