### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_post_data
+# Create Pads from HTTP POST for Etherpad
 
 POST data directly into an Etherpad pad via HTTP.
 


### PR DESCRIPTION
Replace the placeholder `ep_post_data` heading in README.md with "Create Pads from HTTP POST for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.